### PR TITLE
Fix #6464: TMX built-in tile property "type" is now supported. (#6534)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,7 +2,8 @@
 - API Addition: ObjLoader now supports ambientColor, ambientTexture, transparencyTexture, specularTexture and shininessTexture
 - API Addition: PointSpriteParticleBatch blending is now configurable.
 - TOOLS Features: Blending mode and sort mode can be changed in Flame particle 3D editor.
-- API Addition : Polygon have method setVertex (int index, float x, float y)
+- API Addition: Polygon have method setVertex (int index, float x, float y).
+- API Addition: TMX built-in tile property "type" is now supported.
 
 [1.10.0]
 - [BREAKING CHANGE] Android armeabi support has been removed. To migrate your projects: remove any dependency with natives-armeabi qualifier from your gradle build file, this apply to gdx-platform, gdx-bullet-platform, gdx-freetype-platform and gdx-box2d-platform.

--- a/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
+++ b/gdx/src/com/badlogic/gdx/maps/tiled/BaseTmxMapLoader.java
@@ -641,6 +641,10 @@ public abstract class BaseTmxMapLoader<P extends BaseTmxMapLoader.Parameters> ex
 		if (probability != null) {
 			tile.getProperties().put("probability", probability);
 		}
+		String type = tileElement.getAttribute("type", null);
+		if (type != null) {
+			tile.getProperties().put("type", type);
+		}
 		Element properties = tileElement.getChildByName("properties");
 		if (properties != null) {
 			loadProperties(tile.getProperties(), properties);


### PR DESCRIPTION
* TMX built-in tile property "type" is now supported.

* Fixed changes file missing the change.