### PR TITLE
[ORG] RU-MAKEAPP: LWJGL2, LwjglCanvas, ignore failure to set cursor.

### DIFF
--- a/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
+++ b/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglCanvas.java
@@ -240,7 +240,12 @@ public class LwjglCanvas implements LwjglApplicationBase {
 				}
 				try {
 					Display.processMessages();
-					if (cursor != null || !isWindows) canvas.setCursor(cursor);
+					if (cursor != null || !isWindows) {
+						try {
+							canvas.setCursor(cursor);
+						} catch (Throwable ignored) { // Seems to fail on Linux sometimes.
+						}
+					}
 
 					boolean shouldRender = checkResize();
 
@@ -492,7 +497,7 @@ public class LwjglCanvas implements LwjglApplicationBase {
 		this.postedRunnableStacktraces = postedRunnableStacktraces;
 	}
 
-	protected Files createFiles() {
+	protected Files createFiles () {
 		return new LwjglFiles();
 	}
 


### PR DESCRIPTION
See this on Linux, though very rarely:
Caused by: java.lang.UnsatisfiedLinkError: 'int org.lwjgl.opengl.LinuxDisplay.callErrorHandler(long, long, long)'
   at org.lwjgl.opengl.LinuxDisplay.callErrorHandler(LinuxDisplay.java)
   at org.lwjgl.opengl.LinuxDisplay.globalErrorHandler(LinuxDisplay.java:322)
   at java.desktop/sun.awt.X11.XlibWrapper.XFlush(XlibWrapper.java)
   at java.desktop/sun.awt.X11.XComponentPeer.pSetCursor(XComponentPeer.java)
   at java.desktop/sun.awt.X11.XGlobalCursorManager.setCursor(XGlobalCursorManager.java)
   at java.desktop/sun.awt.GlobalCursorManager._updateCursor(GlobalCursorManager.java)
   at sun.awt.GlobalCursorManager.updateCursorImmediately(GlobalCursorManager.java)
   at java.desktop/sun.awt.X11.XComponentPeer.updateCursorImmediately(XComponentPeer.java)
   at java.awt.Component.updateCursorImmediately(Component.java)
   at java.awt.Component.setCursor(Component.java)
   at gdx.lwjgl.LwjglCanvas$3.run(LwjglCanvas.java:243)